### PR TITLE
add .link before .link-wrap to improve edge tooltip

### DIFF
--- a/src/d3-hwschematic.css
+++ b/src/d3-hwschematic.css
@@ -46,7 +46,6 @@
 
 .d3-hwschematic .link {
 	stroke: #000;
-	stroke-opacity: .6;
 	fill: none;
 }
 
@@ -58,7 +57,8 @@
 .d3-hwschematic .link-wrap {
 	stroke-width: 8;
 	fill: none;
-	stroke: transparent;
+    stroke: transparent;
+    stroke-opacity: .6;
 }
 .d3-hwschematic .link-wrap.link-wrap-activated {
 	stroke: deepskyblue;

--- a/src/linkRenderer.js
+++ b/src/linkRenderer.js
@@ -2,6 +2,28 @@ import {section2svgPath} from "./elk/elk-d3-utils.js";
 
 export function renderLinks(root, edges) {
     var junctionPoints = [];
+
+    var link = root.selectAll(".link")
+      .data(edges)
+      .enter()
+      .append("path")
+      .attr("class", "link")
+      .attr("d", function(d) {
+          if (!d.sections) {
+              d._svgPath = "";
+              return "";
+          }
+          if (d.bendpoints || d.sections.length > 1) {
+              throw new Error("NotImplemented");
+          }
+          if(d.junctionPoints)
+              d.junctionPoints.forEach(function (jp) {
+                  junctionPoints.push(jp);
+              });
+          d._svgPath = section2svgPath(d.sections[0]);
+          return d._svgPath;
+      });
+
     var linkWrap = root.selectAll(".link-wrap")
       .data(edges)
       .enter()
@@ -26,27 +48,6 @@ export function renderLinks(root, edges) {
 	           return d.hwMeta.cssStyle
            }
       })
-      .attr("d", function(d) {
-          if (!d.sections) {
-              d._svgPath = "";
-              return "";
-          }
-          if (d.bendpoints || d.sections.length > 1) {
-              throw new Error("NotImplemented");
-          }
-          if(d.junctionPoints)
-              d.junctionPoints.forEach(function (jp) {
-                  junctionPoints.push(jp);
-              });
-          d._svgPath = section2svgPath(d.sections[0]);
-          return d._svgPath;
-      });
-
-    var link = root.selectAll(".link")
-      .data(edges)
-      .enter()
-      .append("path")
-      .attr("class", "link")
       .attr("d", function(d) {
           return d._svgPath;
       });


### PR DESCRIPTION
Hi. Presently hovering the mouse near an edge (in the .link-wrap zone) will display a tooltip but if the mouse is moved directly over the edge (.link) the tooltip disappears. This can be avoided by having d3 append the .links before the .link-wraps and giving .link-wrap an opacity of < 1.