### PR TITLE
or gate close path and draw links before nodes

### DIFF
--- a/src/d3-hwschematic.js
+++ b/src/d3-hwschematic.js
@@ -189,6 +189,8 @@ export default class HwSchematic {
     _applyLayout() {
         var root = this.root;
 
+        this._applyLayoutLinks();
+        
         var node = root.selectAll(".node")
             .data(this._nodes)
             .enter()
@@ -213,7 +215,6 @@ export default class HwSchematic {
                 }
             );
         });
-        this._applyLayoutLinks();
     }
 
     _applyLayoutLinks(root, edges) {

--- a/src/node_renderers/operatorNode_components.js
+++ b/src/node_renderers/operatorNode_components.js
@@ -76,7 +76,7 @@ function NAND(root) {
 }
 
 
-var OR_SHAPE_PATH = "M3,0 A30 25 0 0 1 3,25 A30 25 0 0 0 33,12.5 A30 25 0 0 0 3,0";
+var OR_SHAPE_PATH = "M3,0 A30 25 0 0 1 3,25 A30 25 0 0 0 33,12.5 A30 25 0 0 0 3,0 z";
 /**
  * Draw a OR gate symbol
  */


### PR DESCRIPTION
Two tiny changes to (microscopically :-) )improve image appearance
1. Rendering the links before the nodes means that links do not extend slightly into the node
2. Closing the path of the OR gate results in a nicer shape (top left of the gate)

eg
Before:
<img width="475" alt="Screenshot 2021-03-28 213726" src="https://user-images.githubusercontent.com/4541024/112747448-0903ff00-9012-11eb-89eb-378a699f4f5d.png">

After:
<img width="666" alt="Screenshot 2021-03-28 220221" src="https://user-images.githubusercontent.com/4541024/112747453-13be9400-9012-11eb-965d-91c4744beabb.png">

