### PR TITLE
revert position of applyLayoutLinks to after nodes

### DIFF
--- a/src/d3-hwschematic.js
+++ b/src/d3-hwschematic.js
@@ -188,15 +188,13 @@ export default class HwSchematic {
      */
     _applyLayout() {
         var root = this.root;
-
-        this._applyLayoutLinks();
         
         var node = root.selectAll(".node")
-            .data(this._nodes)
-            .enter()
-            .append("g");
+        .data(this._nodes)
+        .enter()
+        .append("g");
         this.nodeRenderers.render(root, node);
-
+        
         var _this = this;
         node.on("click", function(ev, d) {
             var [children, nextFocusTarget] = toggleHideChildren(d);
@@ -213,8 +211,10 @@ export default class HwSchematic {
                     // Error while applying of layout
                     throw e;
                 }
-            );
-        });
+                );
+            });
+            
+        this._applyLayoutLinks();
     }
 
     _applyLayoutLinks(root, edges) {


### PR DESCRIPTION
Hi Nic30. I'm very sorry but I have uncovered an unanticipated consequence of the last pull request - instance components are also nodes so drawing all "nodes" after the edges means that tool tips wont work for edges within an instance component because the mouseover is obscured by the node. This pull request reverts calling _applyLayoutLinks to original position before drawing nodes.
Apologies again. This could potentially be fixed by adding mouseover event to nodes and propogating the event to overdrawn nodes via getIntersectionList but that is probably overcomplicating things for what was a hacky fix for a minor graphical issue.