### PR TITLE
removed strict null checked when calling zoomToFit

### DIFF
--- a/src/elk/elk-d3.js
+++ b/src/elk/elk-d3.js
@@ -180,7 +180,7 @@ export default class d3elk {
 		if (!this._transformGroup) {
 			return;
 		}
-		if (node === null) {
+		if (!node) {
 			node = this.graph;
 		}
 		zoomToFit(node, this.width, this.height, this._transformGroup);


### PR DESCRIPTION
if the zoomToFit is called without a node it is expected to fit the whole graph however due to the strict null check while node is being undefined in this case it fails throwing an error in the browser so i removed the strict null condition for `!node` which shall cover both null and undefined case